### PR TITLE
Update mdi-team-overrides.yaml

### DIFF
--- a/mdi-team-overrides.yaml
+++ b/mdi-team-overrides.yaml
@@ -12,7 +12,9 @@ teams:
     members:
       - jspaleta
       - xmulligan
+      - joestringer
     mentors:
       - jspaleta
       - xmulligan
+      - joestringer
           


### PR DESCRIPTION
add joestringer as member and mentor to simulaants team.

This PR should not cause any workflow to fire until it is merged into the main branch.

This is an example team composition change intended to be done via a normal public PR process to allow organizational members to request changes in which teams they are currently active and which teams they are mentors in, and are excluded from automatic review rotation.

When this is merged into main, github action workflow will signal the private team-management repo that a team update has occured, and the private repo's team management workflow will fire.

Might want/need to add some pr automation that sanity checks the proposed override changes. But I'm not sure how to do that with the bulk of the management config held in a private repo.